### PR TITLE
changes to be a local install

### DIFF
--- a/lib/SessionHandler.js
+++ b/lib/SessionHandler.js
@@ -47,6 +47,7 @@ class SessionHandler {
             sessions = sessions.filter((session) => fs.lstatSync(path.join(tools.pathToGroup(group), session)).isDirectory());
 
             async.map(sessions, (sessionName, callback) => {
+                console.log( sessionName );
                 var session = new Session(sessionName);
                 session.setGroup(group);
 

--- a/lib/SessionHandler.js
+++ b/lib/SessionHandler.js
@@ -47,7 +47,6 @@ class SessionHandler {
             sessions = sessions.filter((session) => fs.lstatSync(path.join(tools.pathToGroup(group), session)).isDirectory());
 
             async.map(sessions, (sessionName, callback) => {
-                console.log( sessionName );
                 var session = new Session(sessionName);
                 session.setGroup(group);
 

--- a/lib/SessionHandler.js
+++ b/lib/SessionHandler.js
@@ -21,6 +21,9 @@ class SessionHandler {
         fs.readdir(this._basePath, (error, groupNames) => {
             if (error) return callback(error);
 
+            if ( groupNames.indexOf( '.spec.json' ) !== -1 )
+                groupNames = [ './' ];
+
             async.map(groupNames, (groupName, callback) => {
                 var group = new Group(this._basePath, groupName);
 

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -15,7 +15,7 @@ class Session {
     constructor (identifier, isNewSession) {
         isNewSession = isNewSession || false
 
-        this._identifier = identifier || Session.createIdentfier()
+        this._identifier = identifier || 'shotter/' + Session.createIdentfier()
         this._testObjects = []
         this._group = null
         this._isNewSession = isNewSession


### PR DESCRIPTION
small detection fixes that make shotter more usable

- usable installed locally
    `npm run shotter`
    
- no longer dumps a bunch of ugly number folders in the main dir.
    `./shotter/986174606112442`